### PR TITLE
[MVI-1155] (safe-cast) Handle None input

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+
+0.0.9 (2017-03-14)
+------------------
+* Handle None input
+
 0.0.8 (2017-03-12)
 ------------------
 * Rename package to 'safe-cast'

--- a/safe_cast/__init__.py
+++ b/safe_cast/__init__.py
@@ -4,8 +4,8 @@
 #  @namespace smart_cast
 
 __title__ = 'safe-cast'
-__version__ = '0.00.8'
-__build__ = 0x000008
+__version__ = '0.00.9'
+__build__ = 0x000009
 __version_info__ = tuple(__version__.split('.'))
 
 __author__ = 'jefft@tune.com'
@@ -48,7 +48,10 @@ def safe_str(val, default=None):
 
     """
     if val is None:
-        return ''
+        if default:
+            return default
+        else:
+            return ''
     return safe_cast(val, str, default)
 
 
@@ -64,6 +67,12 @@ def safe_float(val, ndigits=2, default=None):
     Returns:
 
     """
+    if val is None:
+        if default:
+            return default
+        else:
+            return float(0.0)
+
     tmp_val = val.replace(',', '') if type(val) == str else val
     return round(safe_cast(tmp_val, float, default), ndigits)
 
@@ -78,6 +87,12 @@ def safe_int(val, default=None):
     Returns:
 
     """
+    if val is None:
+        if default:
+            return default
+        else:
+            return int(0)
+
     return safe_cast(safe_float(val, ndigits=0, default=default), int, default)
 
 
@@ -91,6 +106,12 @@ def safe_dict(val, default=None):
     Returns:
 
     """
+    if val is None:
+        if default:
+            return default
+        else:
+            return {}
+
     return safe_cast(val, dict, default)
 
 
@@ -118,3 +139,7 @@ def safe_smart_cast(val):
 
 def safe_cost(val):
     return safe_float(val, ndigits=4)
+
+
+if __name__=='__main__':
+    pass

--- a/tests/test_smart_cast.py
+++ b/tests/test_smart_cast.py
@@ -10,6 +10,7 @@ from safe_cast import (
     safe_str,
     safe_dict,
     safe_int,
+    safe_cast,
 )
 
 
@@ -86,3 +87,16 @@ def test_safe_dict():
         assert safe_dict(5)
     with pytest.raises(ValueError, message='Expecting ValueError because str not castable to dict.'):
         assert safe_dict('Hello Jeff')
+
+
+def test_None():
+    assert safe_int(None) == 0
+    assert safe_int(None, 7) == 7
+    assert safe_float(None) == 0.0
+    assert safe_float(None, default=7.7) == 7.7
+    assert safe_dict(None) == {}
+    assert safe_dict(None, {'Jeff': 'Tanner'}) == {'Jeff': 'Tanner'}
+    assert safe_str(None) == ''
+    assert safe_str(None, "stas") == "stas"
+    assert safe_cast(None, str) is None
+    assert safe_cast(None, str, default="TuliTuliTuli") == "TuliTuliTuli"


### PR DESCRIPTION
* In case of None input the safe_str returns: '', safe_int: 0,
  safe_float: 0.0 and safe_dict: {}.
* Added testing for the new updates.
* Updated package version to 0.0.9